### PR TITLE
Update virtual-html dependency to 2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "main-loop": "^3.1.0",
     "vdom-to-html": "^2.1.1",
     "virtual-dom": "~2.0.1",
-    "virtual-html": "^1.3.0",
+    "virtual-html": "^2.0.0",
     "virtual-hyperscript-svg": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR updates the `virtual-html` dependency which is an empty package.json to your restored module, 2.0. (Edit: though, full disclosure, I've switched to choo since submitting the PR)
